### PR TITLE
give distinct error variable name

### DIFF
--- a/doc/go_web_application_deploy_container/app/wrap_utils.go
+++ b/doc/go_web_application_deploy_container/app/wrap_utils.go
@@ -43,9 +43,9 @@ func (ca *ContextAdapter) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		// recovered from panic: runtime error: invalid memory address
 		// or nil pointer dereference
 
-		ip, err := getIP(req)
+		ip, ierr := getIP(req)
 		if err != nil {
-			log.Warnf("getIP error: %v", err)
+			log.Warnf("getIP error: %v", ierr)
 		}
 		log.WithFields(log.Fields{
 			"event_type": "error",


### PR DESCRIPTION
Otherwise, it will be logged as `null`.