### PR TITLE
channel is syntactically pointer

### DIFF
--- a/doc/go_concurrency/README.md
+++ b/doc/go_concurrency/README.md
@@ -2491,8 +2491,8 @@ But idiomatic Go should use **channels**:
 
 Try this [code](http://play.golang.org/p/jjHd0YyKO7) with
 `go run -race 34_no_race_with_channel.go`.
-Note that we do not need to pass pointer of channel,
-because channels, like `map` and `slice`, are syntactically pointer,
+Note that we do **not need to pass pointer of channel**,
+because channels, like `map` and `slice`, are **syntactically pointer**,
 as explained [here](https://golang.org/doc/faq#references):
 
 ```go


### PR DESCRIPTION
https://golang.org/doc/faq#references

Why are maps, slices, and channels references while arrays are values?

There's a lot of history on that topic. Early on, maps and channels were syntactically pointers and it was impossible to declare or use a non-pointer instance. Also, we struggled with how arrays should work. Eventually we decided that the strict separation of pointers and values made the language harder to use. Changing these types to act as references to the associated, shared data structures resolved these issues. This change added some regrettable complexity to the language but had a large effect on usability: Go became a more productive, comfortable language when it was introduced.